### PR TITLE
Port to python3 and pygobject-3.x

### DIFF
--- a/pim
+++ b/pim
@@ -27,7 +27,7 @@
 from optparse import OptionParser
 from random import shuffle
 import mimetypes
-import glib
+from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
@@ -132,9 +132,9 @@ class Pim:
     def toggle_slideshow(self):
         self.slideshow = not self.slideshow
         if self.slideshow:
-            self.timer_id = glib.timeout_add_seconds(self.slideshow_delay, self.move_index, 1)
+            self.timer_id = GLib.timeout_add_seconds(self.slideshow_delay, self.move_index, 1)
         else:
-            glib.source_remove(self.timer_id)
+            GLib.source_remove(self.timer_id)
         self.update_title()
 
 

--- a/readme.md
+++ b/readme.md
@@ -4,4 +4,4 @@ All options / bindings can be found at the top of the file in the `__init__` fun
 
 Pim is released under the MIT license.
 
-Dependencies: python2, pygtk
+Dependencies: pygobject (Python bindings for GObject) for python3


### PR DESCRIPTION
As the todo listed python3 I decided to this as a "training". Although in this case it was mostly search and replace.
With these commits it's more or less a 1:1 port. So the same quirks and problems are there (and maybe 1 or 2 more _cough_) Although I planned to work on those. The "less" involves the change of the default background (transparent pictures with black items on a black bg cause a slight problem) and disabling the position saving.
Now to the new issues.
Pressing an unset key result with the py2 version in
  <gtk.gdk.Event at 0xb56a7728: GDK_KEY_PRESS keyval=n>
Now it provides this:
  <void at 0x8fce718>

The other happens with pictures larger than the screen. Now and then scrolling the picture doesn't work.

Well. Enough with the text.
I decided to create the PR as you might be interested in thiss, although the last change is from 2011.
